### PR TITLE
Update vega-lib with the @elastic packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "vega-lib",
-  "version": "3.3.1",
+  "name": "@elastic/vega-lib",
+  "version": "3.3.1-kibana",
   "description": "Include Vega in projeccts using minimal dependencies.",
   "keywords": [
     "vega",
@@ -62,12 +62,12 @@
     "vega-crossfilter": "2",
     "vega-dataflow": "3",
     "vega-encode": "2",
-    "vega-expression": "^2.3",
+    "vega-expression": "npm:@elastic/vega-expression@2.4.0-kibana",
     "vega-force": "2",
     "vega-geo": "^2.2",
     "vega-hierarchy": "^2.1",
     "vega-loader": "2",
-    "vega-parser": "^2.5",
+    "vega-parser": "npm:@elastic/vega-parser@2.7.0-kibana",
     "vega-projection": "1",
     "vega-runtime": "2",
     "vega-scale": "^2.1",
@@ -76,7 +76,7 @@
     "vega-transforms": "^1.2",
     "vega-typings": "*",
     "vega-util": "^1.7",
-    "vega-view": "^2.2",
+    "vega-view": "npm:@elastic/vega-view@2.3.2-kibana",
     "vega-view-transforms": "^1.2",
     "vega-voronoi": "2",
     "vega-wordcloud": "^2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1365,11 +1365,12 @@ vega-event-selector@2:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/vega-event-selector/-/vega-event-selector-2.0.0.tgz#6af8dc7345217017ceed74e9155b8d33bad05d42"
 
-vega-expression@2, vega-expression@^2.3:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/vega-expression/-/vega-expression-2.3.1.tgz#d802a329190bdeb999ce6d8083af56b51f686e83"
+"vega-expression@npm:@elastic/vega-expression@2.4.0-kibana":
+  version "2.4.0-kibana"
+  resolved "https://registry.yarnpkg.com/@elastic/vega-expression/-/vega-expression-2.4.0-kibana.tgz#55de8cb6df5820260cd5beec33ebcfd9ded1cb26"
+  integrity sha512-yK1YZGp7V+RBzMS1v4niqh46m09sr8bn5iGp1TiHp7+bu8eACoBz6KD8q64HI8Kv9qLx+jaJIX5534/YsMlbRg==
   dependencies:
-    vega-util "1"
+    vega-util "^1.7.0"
 
 vega-force@2:
   version "2.0.0"
@@ -1409,9 +1410,10 @@ vega-loader@2:
     topojson-client "3"
     vega-util "1"
 
-vega-parser@2, vega-parser@^2.5:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/vega-parser/-/vega-parser-2.7.0.tgz#974a7c4cd877eafd07b425f842b1ce83cc18e3cf"
+"vega-parser@npm:@elastic/vega-parser@2.7.0-kibana":
+  version "2.7.0-kibana"
+  resolved "https://registry.yarnpkg.com/@elastic/vega-parser/-/vega-parser-2.7.0-kibana.tgz#69584ea30602a2107b577f0b4cb69e8538cfc399"
+  integrity sha512-+fFDT3mQJ1NSU8vvAKrUTRj3Dd2tEyKos+tNx1iJa+y8sngi1j+MunyskREbjNPvpgfHaSF3QZGla35qm6VSBA==
   dependencies:
     d3-array "1"
     d3-color "1"
@@ -1420,7 +1422,7 @@ vega-parser@2, vega-parser@^2.5:
     d3-time-format "2"
     vega-dataflow "3"
     vega-event-selector "2"
-    vega-expression "2"
+    vega-expression "npm:@elastic/vega-expression@2.4.0-kibana"
     vega-scale "2"
     vega-scenegraph "2"
     vega-statistics "^1.2"
@@ -1483,6 +1485,11 @@ vega-util@1, vega-util@^1.7:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.7.0.tgz#0ca0512bb8dcc6541165c34663d115d0712e0cf1"
 
+vega-util@^1.7.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/vega-util/-/vega-util-1.16.0.tgz#77405d8df0a94944d106bdc36015f0d43aa2caa3"
+  integrity sha512-6mmz6mI+oU4zDMeKjgvE2Fjz0Oh6zo6WGATcvCfxH2gXBzhBHmy5d25uW5Zjnkc6QBXSWPLV9Xa6SiqMsrsKog==
+
 vega-view-transforms@^1.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/vega-view-transforms/-/vega-view-transforms-1.2.1.tgz#6114e621e5cc9e59f9db1ecc08a90e23385630d4"
@@ -1491,13 +1498,14 @@ vega-view-transforms@^1.2:
     vega-scenegraph "2"
     vega-util "1"
 
-vega-view@^2.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/vega-view/-/vega-view-2.3.2.tgz#037040b8e64d9dbf7900e86bbc8e952f0b99a119"
+"vega-view@npm:@elastic/vega-view@2.3.2-kibana":
+  version "2.3.2-kibana"
+  resolved "https://registry.yarnpkg.com/@elastic/vega-view/-/vega-view-2.3.2-kibana.tgz#5720e757d4a9b23c42319d434deee04b18690352"
+  integrity sha512-BBpiS8fd7iH5Fl2aput406Czx+keMqv3DmBWOSYgQeXqaIFCFEHJVaOtXTw0T0TSbaMZPJ+4PEHR6osnzUHhDA==
   dependencies:
     d3-array "1"
     vega-dataflow "3"
-    vega-parser "2"
+    vega-parser "npm:@elastic/vega-parser@2.7.0-kibana"
     vega-runtime "2"
     vega-scenegraph "2"
     vega-util "1"


### PR DESCRIPTION
Updated package.json with the @elastic vega packages. If you build it, you will see that vega.js has the fix we want 🙂 
Based on vega-lib 3.3.1